### PR TITLE
13 install instructions cargo ndk

### DIFF
--- a/install_trustchain_mobile.md
+++ b/install_trustchain_mobile.md
@@ -107,7 +107,7 @@ brew info llvm | grep "export PATH"
 ```
 
 ### 7. Install cargo ndk
-`cargo ndk` provides the simplest approach to build for Android targets. This is installed with:
+[`cargo ndk`](https://crates.io/crates/cargo-ndk/) provides the simplest method to build for Android targets. This is installed with:
 ```
 cargo install cargo-ndk
 ```


### PR DESCRIPTION
Updated instructions to only use `cargo-ndk`. Requires testing on a second machine.