### PR TITLE
14 add date chain widget

### DIFF
--- a/lib/app/pages/chain/widget/chain.dart
+++ b/lib/app/pages/chain/widget/chain.dart
@@ -1,6 +1,8 @@
 import 'package:credible/app/pages/chain/models/chain.dart';
+import 'package:credible/app/pages/chain/widget/tile.dart';
 import 'package:credible/app/pages/did/widget/document.dart';
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
 class DIDChainWidgetModel {
   final List<DIDDocumentWidgetModel> data;
@@ -24,49 +26,24 @@ class DIDChainWidget extends StatelessWidget {
     this.trailing,
   }) : super(key: key);
 
-  Widget customChain(DIDDocumentWidgetModel currentDocumentWidget,
-      [String? rootDate]) {
-    return Padding(
-      padding: const EdgeInsets.all(8.0),
-      child: Row(
-        children: [
-          Expanded(
-            flex: 20,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                // if (rootDate != null)
-                //   (Text(
-                //     'ROOT DATE: ' + rootDate,
-                //     style: TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
-                //   )),
-                HumanFriendlyDIDDocumentWidget(
-                  model: currentDocumentWidget,
-                  rootEventDate: rootDate,
-                ),
-              ],
-            ),
-          ),
-          Expanded(flex: 1, child: SizedBox(width: 0, height: 0)),
-          Expanded(
-            flex: 2,
-            child: Icon(
-              Icons.check_circle_rounded,
-              size: 40,
-              color: Color.fromARGB(255, 7, 111, 10),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context) => ListView(
-      children: model.data
-              .take(1)
-              .map((w) =>
-                  customChain(w, DateTime.now().toString().substring(0, 10)))
-              .toList() +
-          model.data.skip(1).map((w) => customChain(w)).toList());
+        padding: const EdgeInsets.all(8.0),
+        children: model.data.isNotEmpty
+            ? model.data.asMap().entries.map((entry) {
+                final index = entry.key;
+                final item = entry.value;
+                final isFirst = index == 0;
+                final isLast = index == model.data.length - 1;
+
+                return CustomTile(
+                  model: item,
+                  isFirst: isFirst,
+                  isLast: isLast,
+                  rootEventDate:
+                      DateFormat('dd MMM yyyy', 'en_US').format(DateTime.now()),
+                );
+              }).toList()
+            : [],
+      );
 }

--- a/lib/app/pages/chain/widget/chain.dart
+++ b/lib/app/pages/chain/widget/chain.dart
@@ -24,21 +24,38 @@ class DIDChainWidget extends StatelessWidget {
     this.trailing,
   }) : super(key: key);
 
-  Widget customChain(DIDDocumentWidgetModel documentWidget, [Color? color]) {
+  Widget customChain(DIDDocumentWidgetModel currentDocumentWidget,
+      [String? rootDate]) {
     return Padding(
       padding: const EdgeInsets.all(8.0),
       child: Row(
         children: [
           Expanded(
-              flex: 20,
-              child: HumanFriendlyDIDDocumentWidget(
-                model: documentWidget,
-              )),
+            flex: 20,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // if (rootDate != null)
+                //   (Text(
+                //     'ROOT DATE: ' + rootDate,
+                //     style: TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
+                //   )),
+                HumanFriendlyDIDDocumentWidget(
+                  model: currentDocumentWidget,
+                  rootEventDate: rootDate,
+                ),
+              ],
+            ),
+          ),
           Expanded(flex: 1, child: SizedBox(width: 0, height: 0)),
           Expanded(
-              flex: 2,
-              child: Icon(Icons.check_circle_rounded,
-                  size: 40, color: Color.fromARGB(255, 7, 111, 10)))
+            flex: 2,
+            child: Icon(
+              Icons.check_circle_rounded,
+              size: 40,
+              color: Color.fromARGB(255, 7, 111, 10),
+            ),
+          ),
         ],
       ),
     );
@@ -48,7 +65,8 @@ class DIDChainWidget extends StatelessWidget {
   Widget build(BuildContext context) => ListView(
       children: model.data
               .take(1)
-              .map((w) => customChain(w, Color.fromARGB(255, 175, 4, 242)))
+              .map((w) =>
+                  customChain(w, DateTime.now().toString().substring(0, 10)))
               .toList() +
           model.data.skip(1).map((w) => customChain(w)).toList());
 }

--- a/lib/app/pages/chain/widget/tile.dart
+++ b/lib/app/pages/chain/widget/tile.dart
@@ -1,0 +1,50 @@
+import 'package:credible/app/pages/did/widget/document.dart';
+import 'package:credible/app/shared/ui/ui.dart';
+import 'package:flutter/material.dart';
+import 'package:timeline_tile/timeline_tile.dart';
+
+class CustomTile extends StatelessWidget {
+  final DIDDocumentWidgetModel model;
+  final String rootEventDate;
+  final bool isFirst;
+  final bool isLast;
+
+  const CustomTile({
+    Key? key,
+    required this.isFirst,
+    required this.isLast,
+    required this.model,
+    required this.rootEventDate,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    const color = Color.fromARGB(255, 7, 111, 10);
+    const lineColor = Color.fromARGB(255, 170, 171, 172);
+    const lineThickness = 1.5;
+    return Container(
+        child: TimelineTile(
+            alignment: TimelineAlign.end,
+            isFirst: isFirst,
+            isLast: isLast,
+            beforeLineStyle: LineStyle(
+              color: lineColor,
+              thickness: lineThickness,
+            ),
+            afterLineStyle: LineStyle(
+              color: lineColor,
+              thickness: lineThickness,
+            ),
+            indicatorStyle: IndicatorStyle(
+                color: color,
+                width: 40,
+                height: 40,
+                iconStyle: IconStyle(
+                    iconData: Icons.done, color: UiKit.palette.credentialText)),
+            startChild: HumanFriendlyDIDDocumentWidget(
+              model: model,
+              rootEventDate: rootEventDate,
+              isRoot: isFirst,
+            )));
+  }
+}

--- a/lib/app/pages/did/widget/document.dart
+++ b/lib/app/pages/did/widget/document.dart
@@ -71,18 +71,21 @@ class HumanFriendlyDIDDocumentWidget extends StatelessWidget {
   final DIDDocumentWidgetModel model;
   final Color? color;
   final Widget? trailing;
-  final String? rootEventDate;
+  final bool isRoot;
+  final String rootEventDate;
 
   const HumanFriendlyDIDDocumentWidget({
     Key? key,
     this.color = const Color.fromARGB(255, 17, 0, 255),
     required this.model,
+    required this.isRoot,
+    required this.rootEventDate,
     this.trailing,
-    this.rootEventDate,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) => Container(
+        margin: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 10.0),
         decoration: BaseBoxDecoration(
           // TODO [#29]: update with different palette for DIDs
           // color: UiKit.palette.credentialBackground,
@@ -104,11 +107,11 @@ class HumanFriendlyDIDDocumentWidget extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               const SizedBox(height: 12.0),
-              // TODO: make option for FirstChainItemWidget
               ChainItemWidget(
                   did: model.did,
                   endpoint: model.endpoint,
-                  rootEventDate: rootEventDate),
+                  rootEventDate: rootEventDate,
+                  isRoot: isRoot),
               const SizedBox(height: 12.0),
             ],
           ),

--- a/lib/app/pages/did/widget/document.dart
+++ b/lib/app/pages/did/widget/document.dart
@@ -71,12 +71,14 @@ class HumanFriendlyDIDDocumentWidget extends StatelessWidget {
   final DIDDocumentWidgetModel model;
   final Color? color;
   final Widget? trailing;
+  final String? rootEventDate;
 
   const HumanFriendlyDIDDocumentWidget({
     Key? key,
     this.color = const Color.fromARGB(255, 17, 0, 255),
     required this.model,
     this.trailing,
+    this.rootEventDate,
   }) : super(key: key);
 
   @override
@@ -102,7 +104,11 @@ class HumanFriendlyDIDDocumentWidget extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               const SizedBox(height: 12.0),
-              ChainItemWidget(did: model.did, endpoint: model.endpoint),
+              // TODO: make option for FirstChainItemWidget
+              ChainItemWidget(
+                  did: model.did,
+                  endpoint: model.endpoint,
+                  rootEventDate: rootEventDate),
               const SizedBox(height: 12.0),
             ],
           ),

--- a/lib/app/pages/did/widget/document.dart
+++ b/lib/app/pages/did/widget/document.dart
@@ -102,18 +102,20 @@ class HumanFriendlyDIDDocumentWidget extends StatelessWidget {
         ),
         child: Padding(
           padding: const EdgeInsets.symmetric(vertical: 5.0, horizontal: 20.0),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              const SizedBox(height: 12.0),
-              ChainItemWidget(
-                  did: model.did,
-                  endpoint: model.endpoint,
-                  rootEventDate: rootEventDate,
-                  isRoot: isRoot),
-              const SizedBox(height: 12.0),
-            ],
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const SizedBox(height: 12.0),
+                ChainItemWidget(
+                    did: model.did,
+                    endpoint: model.endpoint,
+                    rootEventDate: rootEventDate,
+                    isRoot: isRoot),
+                const SizedBox(height: 12.0),
+              ],
+            ),
           ),
         ),
       );

--- a/lib/app/pages/did/widget/item.dart
+++ b/lib/app/pages/did/widget/item.dart
@@ -104,15 +104,14 @@ class ChainItemWidget extends StatelessWidget {
                       borderRadius: BorderRadius.circular(8.0),
                     ),
                     child: Padding(
-                      padding: EdgeInsets.fromLTRB(0.0, 12.0, 8.0, 12.0),
-                      child: Column(
-                        mainAxisSize: MainAxisSize.max,
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: [
-                          JsonViewer({'DID': did, 'endpoint': endpoint})
-                        ],
-                      ),
-                    ))
+                        padding: EdgeInsets.fromLTRB(0.0, 12.0, 8.0, 12.0),
+                        child: Column(
+                          mainAxisSize: MainAxisSize.max,
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            JsonViewer({'DID': did, 'endpoint': endpoint})
+                          ],
+                        )))
               ],
             ),
           )

--- a/lib/app/pages/did/widget/item.dart
+++ b/lib/app/pages/did/widget/item.dart
@@ -25,7 +25,7 @@ class DocumentItemWidget extends StatelessWidget {
             label,
             style: Theme.of(context)
                 .textTheme
-                .overline!
+                .labelSmall!
                 .apply(color: UiKit.palette.credentialText.withOpacity(0.6)),
           ),
           const SizedBox(height: 2.0),
@@ -33,7 +33,7 @@ class DocumentItemWidget extends StatelessWidget {
             value,
             style: Theme.of(context)
                 .textTheme
-                .caption!
+                .bodySmall!
                 .apply(color: UiKit.palette.credentialText),
             maxLines: null,
             softWrap: true,
@@ -45,10 +45,15 @@ class DocumentItemWidget extends StatelessWidget {
 class ChainItemWidget extends StatelessWidget {
   final String did;
   final String endpoint;
-  final String? rootEventDate;
+  final bool isRoot;
+  final String rootEventDate;
 
   const ChainItemWidget(
-      {Key? key, required this.did, required this.endpoint, this.rootEventDate})
+      {Key? key,
+      required this.did,
+      required this.endpoint,
+      required this.rootEventDate,
+      required this.isRoot})
       : super(key: key);
 
   @override
@@ -63,23 +68,14 @@ class ChainItemWidget extends StatelessWidget {
             header: Column(
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
-                if (rootEventDate != null)
+                if (isRoot)
                   (Text(
-                    'ROOT DATE: ' + rootEventDate!,
+                    rootEventDate,
                     style: Theme.of(context)
                         .textTheme
                         .caption!
                         .apply(color: UiKit.palette.credentialText),
                   )),
-                // Text(
-                //   DateFormat('dd MMM yyyy', 'en_US').format(DateTime.now()),
-                //   style: Theme.of(context)
-                //       .textTheme
-                //       .caption!
-                //       .apply(color: UiKit.palette.credentialText),
-                //   maxLines: null,
-                //   softWrap: true,
-                // ),
                 Text(
                   humanReadableEndpoint(endpoint),
                   style: Theme.of(context)

--- a/lib/app/pages/did/widget/item.dart
+++ b/lib/app/pages/did/widget/item.dart
@@ -5,16 +5,16 @@ import 'package:flutter/material.dart';
 import 'package:credible/app/shared/widget/base/box_decoration.dart';
 import 'package:flutter_json_viewer/flutter_json_viewer.dart';
 
-import 'document.dart';
-
 class DocumentItemWidget extends StatelessWidget {
   final String label;
   final String value;
+  final String rootEventDate;
 
   const DocumentItemWidget({
     Key? key,
     required this.label,
     required this.value,
+    this.rootEventDate = '',
   }) : super(key: key);
 
   @override
@@ -45,12 +45,11 @@ class DocumentItemWidget extends StatelessWidget {
 class ChainItemWidget extends StatelessWidget {
   final String did;
   final String endpoint;
+  final String? rootEventDate;
 
-  const ChainItemWidget({
-    Key? key,
-    required this.did,
-    required this.endpoint,
-  }) : super(key: key);
+  const ChainItemWidget(
+      {Key? key, required this.did, required this.endpoint, this.rootEventDate})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) => Column(
@@ -64,6 +63,23 @@ class ChainItemWidget extends StatelessWidget {
             header: Column(
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
+                if (rootEventDate != null)
+                  (Text(
+                    'ROOT DATE: ' + rootEventDate!,
+                    style: Theme.of(context)
+                        .textTheme
+                        .caption!
+                        .apply(color: UiKit.palette.credentialText),
+                  )),
+                // Text(
+                //   DateFormat('dd MMM yyyy', 'en_US').format(DateTime.now()),
+                //   style: Theme.of(context)
+                //       .textTheme
+                //       .caption!
+                //       .apply(color: UiKit.palette.credentialText),
+                //   maxLines: null,
+                //   softWrap: true,
+                // ),
                 Text(
                   humanReadableEndpoint(endpoint),
                   style: Theme.of(context)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,6 +63,7 @@ dependencies:
   freezed_annotation: ^2.2.0
   expandable: ^5.0.1
   flutter_json_viewer: ^1.0.1
+  timeline_tile: ^2.0.0
 
 dev_dependencies:
   build_runner: ^2.3.3


### PR DESCRIPTION
Closes #14

- Add timestamp (format `10 Jan 2023`) to root element of chain display (uses today's day at the moment).  #52 deals with replacing that with date of root event time.
- Cosmetic improvements: use dart library for timelines to connect tick boxes next to chain elements.
 