### PR TITLE
Remove redundant ionEndpoint setting

### DIFF
--- a/flutter-config.json
+++ b/flutter-config.json
@@ -1,5 +1,4 @@
 {
-    "ionEndpoint": "<YOUR_ION_ENDPOINT>",
     "trustchainEndpoint": "<YOUR_TRUSTCHAIN_ENDPOINT>",
     "rootEventTime": "<YOUR_ROOT_EVENT_TIME>"
 }

--- a/install_trustchain_mobile.md
+++ b/install_trustchain_mobile.md
@@ -176,7 +176,6 @@ This runs the code from the branch you have checked out. The mobile app should n
 - Update `flutter-config.json` with your default values, for example:
   ```json
   {
-    "ionEndpoint": "http://trustchain.uksouth.cloudapp.azure.com:3000",
     "trustchainEndpoint": "http://trustchain.uksouth.cloudapp.azure.com:8081",
     "rootEventTime": "1666971942"
   }

--- a/lib/app/pages/on_boarding/gen.dart
+++ b/lib/app/pages/on_boarding/gen.dart
@@ -40,8 +40,6 @@ class _OnBoardingGenPageState extends State<OnBoardingGenPage> {
       await SecureStorageProvider.instance.set(
           ConfigModel.trustchainEndpointKey,
           const String.fromEnvironment('trustchainEndpoint', defaultValue: ''));
-      await SecureStorageProvider.instance.set(ConfigModel.ionEndpointKey,
-          const String.fromEnvironment('ionEndpoint', defaultValue: ''));
       await Modular.to.pushReplacementNamed('/on-boarding/success');
     } catch (error) {
       log.severe('something went wrong when generating a key', error);

--- a/lib/app/pages/profile/blocs/config.dart
+++ b/lib/app/pages/profile/blocs/config.dart
@@ -47,9 +47,6 @@ class ConfigBloc extends Bloc<ConfigEvent, ConfigState> {
 
       final did =
           await SecureStorageProvider.instance.get(ConfigModel.didKey) ?? '';
-      final ionEndpoint = await SecureStorageProvider.instance
-              .get(ConfigModel.ionEndpointKey) ??
-          '';
       final trustchainEndpoint = await SecureStorageProvider.instance
               .get(ConfigModel.trustchainEndpointKey) ??
           '';
@@ -74,7 +71,6 @@ class ConfigBloc extends Bloc<ConfigEvent, ConfigState> {
 
       final model = ConfigModel(
         did: did,
-        ionEndpoint: ionEndpoint,
         trustchainEndpoint: trustchainEndpoint,
         rootEventDate: rootEventDate,
         confirmationCode: confirmationCode,
@@ -108,10 +104,6 @@ class ConfigBloc extends Bloc<ConfigEvent, ConfigState> {
       await SecureStorageProvider.instance.set(
         ConfigModel.didKey,
         did,
-      );
-      await SecureStorageProvider.instance.set(
-        ConfigModel.ionEndpointKey,
-        event.model.ionEndpoint,
       );
       await SecureStorageProvider.instance.set(
         ConfigModel.trustchainEndpointKey,

--- a/lib/app/pages/profile/models/config.dart
+++ b/lib/app/pages/profile/models/config.dart
@@ -4,9 +4,6 @@ class ConfigModel {
   static const String didKey = 'config/did';
   final String did;
 
-  static const String ionEndpointKey = 'config/ionEndpoint';
-  final String ionEndpoint;
-
   static const String trustchainEndpointKey = 'config/trustchainEndpoint';
   final String trustchainEndpoint;
 
@@ -30,7 +27,6 @@ class ConfigModel {
 
   const ConfigModel({
     this.did = '',
-    this.ionEndpoint = '',
     this.trustchainEndpoint = '',
     this.rootEventDate = '',
     this.confirmationCode = '',

--- a/lib/app/pages/profile/pages/config.dart
+++ b/lib/app/pages/profile/pages/config.dart
@@ -28,7 +28,6 @@ class ConfigPage extends StatefulWidget {
 
 class _ConfigPageState extends State<ConfigPage> {
   late TextEditingController did;
-  late TextEditingController ionEndpoint;
   late TextEditingController trustchainEndpoint;
   late RootConfigModel rootConfigModel;
   late TextEditingController confirmationCodeController;
@@ -41,7 +40,6 @@ class _ConfigPageState extends State<ConfigPage> {
     final config_model =
         config_state is ConfigStateDefault ? config_state.model : ConfigModel();
     did = TextEditingController(text: config_model.did);
-    ionEndpoint = TextEditingController(text: config_model.ionEndpoint);
     trustchainEndpoint =
         TextEditingController(text: config_model.trustchainEndpoint);
     // Initialise the root config model:
@@ -76,7 +74,6 @@ class _ConfigPageState extends State<ConfigPage> {
           // TODO: save not working here
           Modular.get<ConfigBloc>().add(ConfigEventUpdate(ConfigModel(
             did: did.text,
-            ionEndpoint: ionEndpoint.text,
             trustchainEndpoint: trustchainEndpoint.text,
             rootEventDate: _rootEventDateIsSet.value
                 ? rootConfigModel.date.toString()
@@ -196,13 +193,6 @@ class _ConfigPageState extends State<ConfigPage> {
                 );
               },
             ),
-          ),
-          const SizedBox(height: 16.0),
-          BaseTextField(
-            label: localizations.ionEndpoint,
-            controller: ionEndpoint,
-            icon: Icons.http_sharp,
-            textCapitalization: TextCapitalization.words,
           ),
           const SizedBox(height: 16.0),
           BaseTextField(

--- a/lib/app/shared/config.dart
+++ b/lib/app/shared/config.dart
@@ -15,11 +15,6 @@ class FFIConfig {
         .get(ConfigModel.trustchainEndpointKey))!;
   }
 
-  Future<String> get_ion_endpoint() async {
-    return (await SecureStorageProvider.instance
-        .get(ConfigModel.ionEndpointKey))!;
-  }
-
   Future<String> get_did() async {
     return (await SecureStorageProvider.instance.get(ConfigModel.didKey))!;
   }
@@ -28,13 +23,7 @@ class FFIConfig {
     var ffiConfig = Constants.ffiConfig;
     ffiConfig['trustchainOptions']!['rootEventTime'] =
         await get_root_event_time();
-    final ionEndpoint = await get_ion_endpoint();
     final trustchainEndpoint = await get_trustchain_endpoint();
-    final ionEndpointUri = Uri.parse(ionEndpoint);
-
-    ffiConfig['endpointOptions']!['ionEndpoint']!['host'] =
-        ionEndpointUri.toString();
-    ffiConfig['endpointOptions']!['ionEndpoint']!['port'] = ionEndpointUri.port;
     final trustchainEndpointUri = Uri.parse(trustchainEndpoint);
     ffiConfig['endpointOptions']!['trustchainEndpoint']!['host'] =
         trustchainEndpointUri.toString();

--- a/lib/app/shared/constants.dart
+++ b/lib/app/shared/constants.dart
@@ -6,7 +6,6 @@ class Constants {
   // TODO [#41]: remove/move to tests.
   static final ffiConfig = {
     'endpointOptions': {
-      'ionEndpoint': {'host': '10.0.2.2', 'port': 3000},
       'trustchainEndpoint': {'host': '10.0.2.2', 'port': 8081}
     },
     'trustchainOptions': {'rootEventTime': 1666971942, 'signatureOnly': false},

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -167,7 +167,6 @@
   "configSubtitle": "Settings",
   "didLabel": "My DID:",
   "rootEventTime": "Root Event Time:",
-  "ionEndpoint": "ION endpoint:",
   "trustchainEndpoint": "Trustchain endpoint:",
   "rootEventDate": "Root event date:",
   "setRootEventDate": "Set root event date",


### PR DESCRIPTION
Closes #60.

With the backend changes to `trustchain-ffi` in PR https://github.com/alan-turing-institute/trustchain/pull/137, the ionEndpoint setting on mobile is now redundant. This PR removes the setting throughout the app.

Trustchain FFI libraries must be rebuilt after pulling the `trustchain-ffi` changes (using the `cargo ndk` command given in the [mobile install instructions](https://github.com/alan-turing-institute/trustchain-mobile/blob/dev/install_trustchain_mobile.md#9-build-trustchain-targets)) before testing the changes on mobile.