### PR TITLE
Fix FFI config for trustchain endpoint with non-default port

### DIFF
--- a/lib/app/shared/config.dart
+++ b/lib/app/shared/config.dart
@@ -32,8 +32,11 @@ class FFIConfig {
         await get_root_event_time();
     final trustchainEndpoint = await get_trustchain_endpoint();
     final trustchainEndpointUri = Uri.parse(trustchainEndpoint);
+    // Ensure scheme is HTTP or HTTPS
+    assert(trustchainEndpointUri.isScheme('HTTP') ||
+        trustchainEndpointUri.isScheme('HTTPS'));
     ffiConfig['endpointOptions']!['trustchainEndpoint']!['host'] =
-        trustchainEndpointUri.toString();
+        trustchainEndpointUri.scheme + '://' + trustchainEndpointUri.host;
     ffiConfig['endpointOptions']!['trustchainEndpoint']!['port'] =
         trustchainEndpointUri.port;
     return ffiConfig;


### PR DESCRIPTION
A fix to ensure that when an endpoint is parsed to a URI with an explicit port, only the scheme and host are combined when constructing the FFI config.

On the Trustchain resolution side, the error returned currently is `invalidDID` which was not very informative. This would be improved by the related issue https://github.com/alan-turing-institute/trustchain/issues/126