### PR TITLE
Rename app from Credible to Trustchain

### DIFF
--- a/lib/app/app_widget.dart
+++ b/lib/app/app_widget.dart
@@ -79,7 +79,7 @@ class _AppWidgetState extends State<AppWidget> {
     Modular.setInitialRoute('/splash');
 
     return MaterialApp.router(
-      title: 'Credible',
+      title: 'Trustchain',
       theme: _themeData,
       routeInformationParser: Modular.routeInformationParser,
       routerDelegate: Modular.routerDelegate,

--- a/lib/app/shared/widget/app_version.dart
+++ b/lib/app/shared/widget/app_version.dart
@@ -15,7 +15,7 @@ class AppVersion extends StatelessWidget {
       builder: (context, snapshot) {
         switch (snapshot.connectionState) {
           case ConnectionState.done:
-            final appName = snapshot.data?.appName ?? 'Credible';
+            final appName = snapshot.data?.appName ?? 'Trustchain';
             final version = snapshot.data?.version ?? '0.1.0';
             final buildNumber = snapshot.data?.buildNumber ?? '1';
 


### PR DESCRIPTION
Partially addresses #29.

During installation the app name still appears as "Credible". This renames it to "Trustchain".