### PR TITLE
Add warning on stale VP verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
       - main
       - e2etests
   pull_request:
+    branches:
+      - main
 
 env:
   flutter_version: "1.27.0-1.0.pre"
@@ -21,26 +23,26 @@ jobs:
     steps:
       
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         path: main
 
     - name: Cache didkit
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: cache-didkit
       with:
         path: didkit
         key: ${{ runner.os }}-${{ env.didkit_version }}
 
     - name: Cache ssi
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: cache-ssi
       with:
         path: ssi
         key: ${{ runner.os }}-${{ env.ssi_version }}
 
     - name: Cache Flutter dependencies
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       id: cache-flutter
       with:
         path: /opt/hostedtoolcache/flutter
@@ -48,14 +50,14 @@ jobs:
 
     # Clones didkit
     - name: Clone didkit
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: spruceid/didkit
         path: didkit
 
     # Clones ssi
     - name: Clone SSI
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: spruceid/ssi
         path: ssi
@@ -74,7 +76,7 @@ jobs:
         channel: 'dev'
 
     - name: SETUP | Rust
-      uses: ATiltedTree/setup-rust@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         rust-version: nightly
   
@@ -94,7 +96,7 @@ jobs:
     #   working-directory: ./main
     #   run: flutter build apk --release
 
-    # - uses: actions/upload-artifact@v2
+    # - uses: actions/upload-artifact@v4
     #   with:
     #     name: app-release.apk
     #     path: ./main/build/app/outputs/apk/release/app-release.apk
@@ -120,20 +122,20 @@ jobs:
     steps:
       
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         path: main
 
     # Clones didkit
     - name: Clone didkit
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: spruceid/didkit
         path: didkit
 
     # Clones ssi
     - name: Clone SSI
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: spruceid/ssi
         path: ssi
@@ -146,7 +148,7 @@ jobs:
         channel: 'dev'
 
     - name: SETUP | Rust
-      uses: ATiltedTree/setup-rust@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         rust-version: nightly
   

--- a/lib/app/pages/credentials/pages/presentation_viewer.dart
+++ b/lib/app/pages/credentials/pages/presentation_viewer.dart
@@ -47,9 +47,26 @@ class _PresentationViewerState
     try {
       await trustchain_ffi.vpVerifyPresentation(
           presentation: widget.presentation, opts: opts);
-      setState(() {
-        verification = VerificationState.Verified;
-      });
+      // If the presentation is more than 15 minutes old, display a warning.
+      assert(json.containsKey('proof'));
+      assert(json['proof'].containsKey('created'));
+      final vp_timestamp = DateTime.parse(json['proof']['created']);
+      final vp_age = DateTime.now().difference(vp_timestamp);
+      if (vp_age < Duration(minutes: 15)) {
+        setState(() {
+          verification = VerificationState.Verified;
+        });
+      } else {
+        setState(() {
+          verification = VerificationState.VerifiedWithWarning;
+        });
+        final localizations = AppLocalizations.of(context)!;
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+          backgroundColor: VerificationState.VerifiedWithWarning.color,
+          content:
+              Text(localizations.stalePresentationWarning(vp_age.inMinutes)),
+        ));
+      }
     } on FfiException catch (err) {
       print(err);
       setState(() {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -187,5 +187,14 @@
   "presentationSuccessButton": "Ok",
   "presentationFailTitle": "Failed presentation",
   "presentationFailSubtitle": "Presentation was successfully presented",
-  "presentationFailButton": "Ok"
+  "presentationFailButton": "Ok",
+  "stalePresentationWarning": "This presentation is more than {ageInMinutes} minutes old",
+  "@stalePresentationWarning": {
+    "placeholders": {
+      "ageInMinutes": {
+        "type": "int",
+        "example": "15"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -128,6 +128,15 @@
   "personalLastName": "Nom",
   "personalPhone": "Téléphone",
   "personalLocation": "Adresse",
-  "personalMail": "Email"
+  "personalMail": "Email",
+  "stalePresentationWarning": "Cette présentation a plus de {ageInMinutes} minutes",
+  "@stalePresentationWarning": {
+    "placeholders": {
+      "ageInMinutes": {
+        "type": "int",
+        "example": "15"
+      }
+    }
+  }
 }
 


### PR DESCRIPTION
Closes #91.

Updates TinyVP outcome when verifying a VP that is more than 15 old.

Previously, in this case, the verification status was "Verified", with a green tick. Now the status is "Verified (with warnings)", with an orange exclamation mark, and a warning message is displayed "This presentation is more than {ageInMinutes} minutes old".  (See attached screenshot.)

This change adds non-transferability protection, preventing a VC holder from creating a VP and fraudulently sharing the QR code image with others.

<img width="312" alt="Screenshot 2025-03-13 at 22 36 38" src="https://github.com/user-attachments/assets/69b2cf40-dfb0-47a5-8378-4cc4c8ba377d" />
